### PR TITLE
Add whisper-based summarization server

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -215,7 +215,7 @@ async fn send_wav(filename: &str) -> Result<(), Box<dyn std::error::Error>> {
     let form = reqwest::multipart::Form::new().part("file", part);
 
     let response = client
-        .post("http://your-server-endpoint/upload")
+        .post("http://localhost:8000/upload")
         .multipart(form)
         .send()
         .await?;

--- a/server-rs/Cargo.lock
+++ b/server-rs/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +62,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -111,6 +121,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,10 +174,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -175,6 +234,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -238,6 +303,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,6 +322,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -271,9 +353,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -293,6 +377,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -318,6 +408,12 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "http"
@@ -583,6 +679,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +708,16 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.53.2",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -651,6 +766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -671,6 +792,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.3.1",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +823,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -803,6 +951,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +992,35 @@ checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -880,6 +1067,12 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1021,11 +1214,14 @@ name = "server-rs"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "futures-util",
+ "hound",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "toml",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -1064,6 +1260,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1319,6 +1521,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +1629,27 @@ checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03469c15b9529a30cdf866ea2391b8236922a12a87b9d9f1973a258e748d56d"
+dependencies = [
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee89fab2a5d40cb603ab8595605374823ca1405124efb9c806c2d98f6847430"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
 ]
 
 [[package]]

--- a/server-rs/Cargo.toml
+++ b/server-rs/Cargo.toml
@@ -4,9 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.7"
+axum = { version = "0.7", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 toml = "0.7"
+whisper-rs = "0.14"
+hound = "3.5"
+futures-util = "0.3"

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -1,11 +1,11 @@
 # Rust Summarization Server
 
-This Rust server receives transcript text and periodically summarizes it using an OpenAI-compatible API. Every five minutes the summary is sent to a webhook. If no text is received for one hour, the remaining buffered text is summarized and flushed.
+This Rust server receives WAV audio files, transcribes them with `whisper-rs` and updates an incident summary using an OpenAI-compatible API. If no audio is received for one hour, the summary is cleared.
 
 ## Requirements
 - Rust toolchain
 - `OPENAI_API_KEY` environment variable set to a valid OpenAI API key
-- `config.toml` file describing API and webhook settings
+- `config.toml` file describing API, webhook and whisper model settings
 
 ## Running
 
@@ -15,14 +15,13 @@ cargo run --release --manifest-path server-rs/Cargo.toml
 
 The server listens on `http://localhost:8000` by default.
 
-Send transcript text to `/transcript`:
+Send a WAV file to `/upload` using multipart form data:
 
 ```bash
-curl -X POST -H "Content-Type: application/json" \
-     -d '{"text":"some transcript"}' http://localhost:8000/transcript
+curl -F file=@audio.wav http://localhost:8000/upload
 ```
 
-Summaries are automatically sent to the configured webhook every five minutes (or sooner after one hour of inactivity).
+Each uploaded audio file updates the summary which is sent to the configured webhook. If no files are uploaded for an hour, the summary is cleared.
 
 ## Configuration
 
@@ -33,6 +32,7 @@ openai_api_url = "https://api.openai.com/v1/chat/completions"
 openai_model = "gpt-3.5-turbo"
 webhook_url = "https://example.com/webhook"
 webhook_template = '{"summary":"{summary}"}'
+whisper_model_path = "models/ggml-base.en.bin"
 ```
 
 `webhook_template` is a JSON string where `{summary}` will be replaced with the generated summary before sending the request.

--- a/server-rs/config.toml
+++ b/server-rs/config.toml
@@ -3,3 +3,4 @@ openai_model = "gpt-3.5-turbo"
 webhook_url = "https://example.com/webhook"
 # JSON template for the webhook payload; {summary} will be replaced
 webhook_template = '{"summary":"{summary}"}'
+whisper_model_path = "models/ggml-base.en.bin"

--- a/server-rs/src/main.rs
+++ b/server-rs/src/main.rs
@@ -1,18 +1,20 @@
-use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
+use axum::{
+    extract::{Multipart, State},
+    http::StatusCode,
+    routing::post,
+    Router,
+};
+use hound;
 use serde::Deserialize;
 use serde_json::json;
 use std::env;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
 use tokio::fs;
+use tokio::sync::Mutex;
 use toml;
-
-#[derive(Deserialize)]
-struct TranscriptRequest {
-    text: String,
-}
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
 #[derive(Clone, Deserialize)]
 struct Config {
@@ -20,50 +22,91 @@ struct Config {
     openai_model: String,
     webhook_url: String,
     webhook_template: String,
+    whisper_model_path: String,
 }
 
 struct SharedState {
-    buffer: String,
+    summary: String,
     last_received: Instant,
-    last_summary: Instant,
+    ctx: WhisperContext,
 }
 
-impl Default for SharedState {
-    fn default() -> Self {
+impl SharedState {
+    fn new(model_path: &str) -> Self {
+        let ctx = WhisperContext::new_with_params(model_path, WhisperContextParameters::default())
+            .expect("failed to load model");
         Self {
-            buffer: String::new(),
+            summary: String::new(),
             last_received: Instant::now(),
-            last_summary: Instant::now(),
+            ctx,
         }
     }
 }
 
 type StateHandle = Arc<Mutex<SharedState>>;
 
+#[derive(Clone)]
+struct AppState {
+    shared: StateHandle,
+    config: Arc<Config>,
+    key: Arc<String>,
+}
+
 async fn load_config() -> Config {
     let path = env::var("CONFIG_FILE").unwrap_or_else(|_| "server-rs/config.toml".to_string());
-    let text = fs::read_to_string(&path).await.expect("failed to read config file");
+    let text = fs::read_to_string(&path)
+        .await
+        .expect("failed to read config file");
     toml::from_str(&text).expect("invalid config")
 }
 
-async fn add_transcript(
-    State(state): State<StateHandle>,
-    Json(req): Json<TranscriptRequest>,
-) -> StatusCode {
-    let mut s = state.lock().await;
-    if !s.buffer.is_empty() {
-        s.buffer.push('\n');
+async fn transcribe_wav(data: Vec<u8>, state: &mut SharedState) -> Result<String, String> {
+    let cursor = std::io::Cursor::new(data);
+    let mut reader = hound::WavReader::new(cursor).map_err(|e| e.to_string())?;
+    let spec = reader.spec();
+    if spec.channels != 1 || spec.sample_rate != 16_000 {
+        return Err("wav must be mono 16kHz".to_string());
     }
-    s.buffer.push_str(&req.text);
-    s.last_received = Instant::now();
-    StatusCode::OK
+    let samples: Vec<i16> = reader
+        .samples::<i16>()
+        .map(|s| s.unwrap_or_default())
+        .collect();
+    let mut float_samples = vec![0.0f32; samples.len()];
+    whisper_rs::convert_integer_to_float_audio(&samples, &mut float_samples)
+        .map_err(|e| e.to_string())?;
+
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    params.set_language(Some("en"));
+    params.set_print_special(false);
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_timestamps(false);
+
+    let mut wstate = state.ctx.create_state().map_err(|e| e.to_string())?;
+    wstate
+        .full(params, &float_samples[..])
+        .map_err(|e| e.to_string())?;
+
+    let num_segments = wstate.full_n_segments().map_err(|e| e.to_string())?;
+    let mut text = String::new();
+    for i in 0..num_segments {
+        let seg = wstate.full_get_segment_text(i).map_err(|e| e.to_string())?;
+        text.push_str(seg.trim());
+        text.push(' ');
+    }
+    Ok(text)
 }
 
-async fn summarize_text(text: &str, key: &str, api_url: &str, model: &str) -> Result<String, String> {
+async fn summarize_text(
+    prompt: String,
+    key: &str,
+    api_url: &str,
+    model: &str,
+) -> Result<String, String> {
     let client = reqwest::Client::new();
     let body = json!({
         "model": model,
-        "messages": [{"role": "user", "content": format!("Summarize the following text in a few sentences:\n{}", text)}]
+        "messages": [{"role": "user", "content": prompt}]
     });
 
     let res = client
@@ -87,6 +130,9 @@ async fn summarize_text(text: &str, key: &str, api_url: &str, model: &str) -> Re
 }
 
 async fn post_webhook(url: &str, template: &str, summary: &str) {
+    if url.is_empty() {
+        return;
+    }
     let payload = template.replace("{summary}", summary);
     let client = reqwest::Client::new();
     let _ = client
@@ -97,49 +143,82 @@ async fn post_webhook(url: &str, template: &str, summary: &str) {
         .await;
 }
 
-#[tokio::main]
-async fn main() {
-    let key = env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set");
-    let config = load_config().await;
-
-    let state = Arc::new(Mutex::new(SharedState::default()));
-    let state_bg = state.clone();
-    let key_bg = key.clone();
-    let cfg_bg = config.clone();
-
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(Duration::from_secs(60));
-        loop {
-            interval.tick().await;
-            let mut s = state_bg.lock().await;
-            let now = Instant::now();
-            let since_recv = now.duration_since(s.last_received);
-            let since_summary = now.duration_since(s.last_summary);
-
-            if !s.buffer.is_empty() && since_summary >= Duration::from_secs(300) {
-                let text = std::mem::take(&mut s.buffer);
-                s.last_summary = now;
-                drop(s);
-                if let Ok(summary) = summarize_text(&text, &key_bg, &cfg_bg.openai_api_url, &cfg_bg.openai_model).await {
-                    post_webhook(&cfg_bg.webhook_url, &cfg_bg.webhook_template, &summary).await;
-                }
-                continue;
-            }
-
-            if since_recv >= Duration::from_secs(3600) && !s.buffer.is_empty() {
-                let text = std::mem::take(&mut s.buffer);
-                s.last_summary = now;
-                drop(s);
-                if let Ok(summary) = summarize_text(&text, &key_bg, &cfg_bg.openai_api_url, &cfg_bg.openai_model).await {
-                    post_webhook(&cfg_bg.webhook_url, &cfg_bg.webhook_template, &summary).await;
-                }
+async fn upload_audio(State(app): State<AppState>, mut multipart: Multipart) -> StatusCode {
+    let state = &app.shared;
+    let cfg = &app.config;
+    let key = &app.key;
+    let mut data = None;
+    while let Some(field) = multipart.next_field().await.unwrap() {
+        if let Some(name) = field.name() {
+            if name == "file" {
+                data = Some(field.bytes().await.unwrap().to_vec());
+                break;
             }
         }
-    });
+    }
+
+    let data = match data {
+        Some(d) => d,
+        None => return StatusCode::BAD_REQUEST,
+    };
+
+    let mut s = state.lock().await;
+    s.last_received = Instant::now();
+    let transcription = match transcribe_wav(data, &mut s).await {
+        Ok(t) => t,
+        Err(_) => return StatusCode::BAD_REQUEST,
+    };
+
+    let prompt = if s.summary.is_empty() {
+        format!("Summarize this transcription: {}\n\nWith this template:\n### 🔴 Incident Summary\n\n**Time:** <START_TIME> – <END_TIME>  \n**Status:** <⚠️ Ongoing / ✅ Resolved / 🕓 Monitoring>  \n**Severity:** <SEV-1 / SEV-2 / SEV-3>  \n**Detected By:** <Monitoring / User Reports / Other>\n\n**Impact:**  \n<Brief description of the impact. Who/what was affected? Include user-facing symptoms, affected services, environments, or regions.>\n\n**Root Cause (Preliminary):**  \n<Short technical description of what caused the incident.>\n\n**Actions Taken:**  \n- <[TIMESTAMP]> <Action #1>  \n- <[TIMESTAMP]> <Action #2>  \n- …\n\n**Next Steps / Preventative Actions:**  \n- [ ] <Fix or mitigation #1>  \n- [ ] <Fix or mitigation #2>  \n- …\n\n**Owner:** <@team-or-person>  \n**Links:**  \n- Dashboard: <link>  \n- Logs: <link>  \n- Incident Tracker: <link>  \n- Postmortem: <link or TBD>", transcription)
+    } else {
+        format!("Here is text summary:\n{}\nPlease update this summary with new infroamtion from this transcription:\n{}", s.summary, transcription)
+    };
+
+    drop(s);
+    let mut s = state.lock().await;
+    match summarize_text(prompt, &key, &cfg.openai_api_url, &cfg.openai_model).await {
+        Ok(sum) => {
+            s.summary = sum.clone();
+            post_webhook(&cfg.webhook_url, &cfg.webhook_template, &sum).await;
+            StatusCode::OK
+        }
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+async fn flush_task(state: StateHandle) {
+    let mut interval = tokio::time::interval(Duration::from_secs(60));
+    loop {
+        interval.tick().await;
+        let mut s = state.lock().await;
+        if !s.summary.is_empty()
+            && Instant::now().duration_since(s.last_received) >= Duration::from_secs(3600)
+        {
+            s.summary.clear();
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let key = Arc::new(env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY not set"));
+    let config = load_config().await;
+    let state = Arc::new(Mutex::new(SharedState::new(&config.whisper_model_path)));
+
+    let state_bg = state.clone();
+    tokio::spawn(flush_task(state_bg));
+
+    let app_state = AppState {
+        shared: state.clone(),
+        config: Arc::new(config.clone()),
+        key: key.clone(),
+    };
 
     let app = Router::new()
-        .route("/transcript", post(add_transcript))
-        .with_state(state);
+        .route("/upload", post(upload_audio))
+        .with_state(app_state);
+
     let addr = SocketAddr::from(([127, 0, 0, 1], 8000));
     println!("Listening on http://{}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();


### PR DESCRIPTION
## Summary
- update repo docs with new whisper-based workflow
- change client to post audio to the new `/upload` endpoint
- implement whisper-based server in Rust without Python

## Testing
- `cargo build --manifest-path server-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_6854a9e930588333a180d122251f1f03