### PR TITLE
Add Dockerfile for Rust server

### DIFF
--- a/server-rs/Dockerfile
+++ b/server-rs/Dockerfile
@@ -1,0 +1,19 @@
+# Build stage
+FROM rust:1.74 as builder
+WORKDIR /usr/src/app
+COPY . .
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:bullseye-slim
+RUN apt-get update && apt-get install -y ca-certificates wget && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /usr/src/app/target/release/server-rs /usr/local/bin/server-rs
+COPY config.toml /app/config.toml
+# Download default Whisper model
+RUN mkdir -p models && \
+    wget -O models/ggml-base.en.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+
+ENV CONFIG_FILE=/app/config.toml
+EXPOSE 8000
+CMD ["/usr/local/bin/server-rs"]

--- a/server-rs/README.md
+++ b/server-rs/README.md
@@ -36,3 +36,27 @@ whisper_model_path = "models/ggml-base.en.bin"
 ```
 
 `webhook_template` is a JSON string where `{summary}` will be replaced with the generated summary before sending the request.
+
+## Pulling the Whisper model
+
+`whisper-rs` expects a `.bin` model file. The default configuration points to
+`models/ggml-base.en.bin`. Download the model once before running the server:
+
+```bash
+mkdir -p server-rs/models
+curl -L -o server-rs/models/ggml-base.en.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin
+```
+
+## Docker
+
+`server-rs/Dockerfile` builds the server binary and fetches the whisper model at
+image build time. Build and run the image:
+
+```bash
+docker build -t summary-server ./server-rs
+docker run -p 8000:8000 -e OPENAI_API_KEY=your-key summary-server
+```
+
+The container exposes port `8000` and uses `config.toml` from the image. Supply a
+valid `OPENAI_API_KEY` at runtime.


### PR DESCRIPTION
## Summary
- include Dockerfile for `server-rs`
- document how to download the Whisper model
- document building and running the Docker image

## Testing
- `make check` *(fails for `client` because of missing `alsa` system library)*

------
https://chatgpt.com/codex/tasks/task_e_6854aea7ccbc8333b09030c36fc4977b