### PR TITLE
Add runtime docs and systemd units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+bin/
 
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,31 @@
-.PHONY: check run-server
+.PHONY: check run-server run-client build-server build-client build
+
+BIN_DIR := bin
 
 # Build both Rust crates to ensure the code compiles
 check:
 	cargo check --manifest-path server-rs/Cargo.toml
 	cargo check --manifest-path client/Cargo.toml || true
 
+# Build the server binary
+build-server:
+	cargo build --release --manifest-path server-rs/Cargo.toml
+	mkdir -p $(BIN_DIR)
+	cp server-rs/target/release/server-rs $(BIN_DIR)/
+
+# Build the client binary
+build-client:
+	cargo build --release --manifest-path client/Cargo.toml
+	mkdir -p $(BIN_DIR)
+	cp client/target/release/client_app $(BIN_DIR)/
+
+# Build both binaries
+build: build-server build-client
+
 # Run the summarization server
 run-server:
 	cargo run --manifest-path server-rs/Cargo.toml
+
+# Run the audio client
+run-client:
+	cargo run --manifest-path client/Cargo.toml -- --system-key default

--- a/README.md
+++ b/README.md
@@ -24,3 +24,62 @@ See [`server-rs`](server-rs/) for details about the Rust server and configuratio
    ```
 The server posts an updated summary after each upload and clears it after an hour of inactivity.
 
+## Building
+
+Build both binaries with `make`:
+
+```bash
+make build
+```
+
+The binaries are placed in the `bin/` directory. `build-server` and `build-client` targets are also available.
+
+## Running
+
+Run the server or client directly through `make`:
+
+```bash
+make run-server    # start the summarization server
+make run-client    # start the audio client using system-key "default"
+```
+
+## Configuration
+
+`server-rs/config.toml` contains default settings for the server:
+
+```toml
+openai_api_url = "https://api.openai.com/v1/chat/completions"
+openai_model = "gpt-3.5-turbo"
+webhook_url = "https://example.com/webhook"
+webhook_template = '{"summary":"{summary}"}'
+whisper_model_path = "models/ggml-base.en.bin"
+database_url = "postgres://user:password@localhost/summary"
+
+[[systems]]
+key = "default"
+initial_prompt = "..."
+update_prompt = "..."
+```
+
+Adjust these values or point `CONFIG_FILE` to another path when running the server.
+
+## Systemd Units
+
+Example service files are provided under [`contrib/systemd`](contrib/systemd):
+
+```bash
+sudo cp contrib/systemd/summary-server.service /etc/systemd/system/
+sudo cp contrib/systemd/summary-client.service /etc/systemd/system/
+```
+
+Enable and start the services with `systemctl enable --now summary-server summary-client`.
+
+## Docker
+
+`server-rs/Dockerfile` builds the server along with the default Whisper model. Build and run the image:
+
+```bash
+docker build -t summary-server ./server-rs
+docker run -p 8000:8000 -e OPENAI_API_KEY=your-key summary-server
+```
+

--- a/contrib/systemd/summary-client.service
+++ b/contrib/systemd/summary-client.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=ETT Summary Client
+After=sound.target network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/ett-summary
+ExecStart=/opt/ett-summary/bin/client_app --system-key default
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/contrib/systemd/summary-server.service
+++ b/contrib/systemd/summary-server.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=ETT Summary Server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/ett-summary
+Environment=OPENAI_API_KEY=your-key
+Environment=CONFIG_FILE=/opt/ett-summary/server-rs/config.toml
+ExecStart=/opt/ett-summary/bin/server-rs
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- document build commands, running server and client, configuration and Docker usage
- add sample systemd units
- extend Makefile with `run-client` target

## Testing
- `make check` *(fails building `alsa-sys` but command continues)*

------
https://chatgpt.com/codex/tasks/task_e_6856d931e964833384e8cb4e2f208e00